### PR TITLE
Update dependencies

### DIFF
--- a/notebooks/prediction-challenge/minimum-working-example.ipynb
+++ b/notebooks/prediction-challenge/minimum-working-example.ipynb
@@ -103,6 +103,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip uninstall scikit-learn -y\n",
+    "!pip install scikit-learn==0.23.2\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from scipy.stats import uniform\n",


### PR DESCRIPTION
The parameter 'iid' is deprecated in 0.22 and will be removed in 0.24.